### PR TITLE
Add mdEdit class instead of replacing existing classes

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -15,7 +15,8 @@ function Editor(el, opts){
 
   var cname = opts['className'] || '';
 
-  this.el.className = 'mdedit' + (cname ? ' ' + cname : '');
+  this.el.className = this.el.className ? this.el.className + ' ' : '';
+  this.el.className += 'mdedit' + (cname ? ' ' + cname : '');
   this.el.setAttribute('contenteditable', true);
 
   this.selMgr = new SelectionManager(el);


### PR DESCRIPTION
Currently classes on the editor element are replaced by the `mdEdit` class. This pull request instead appends the `mdEdit` class to all existing classes.
