### PR TITLE
set charset of html to UTF-8

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <script src="prism-all.js"></script>
   <link rel="stylesheet" href="prism.css">
   <link rel="stylesheet" href="mdedit.css">


### PR DESCRIPTION
Unknown why, the encoding of html is not recognized as `UTF-8` when using `file://` while `http://` work well, which cause that some unicode chars in javascript is not recognized and failed to run it.

The same with https://github.com/jbt/markdown-editor/
